### PR TITLE
add "multi" in @EXPORT_OK to export it with "-all", as is documented

### DIFF
--- a/lib/Kavorka.pm
+++ b/lib/Kavorka.pm
@@ -18,7 +18,7 @@ our $VERSION   = '0.029';
 
 our @ISA         = qw( Exporter::Tiny );
 our @EXPORT      = qw( fun method );
-our @EXPORT_OK   = qw( fun method after around before override augment classmethod objectmethod );
+our @EXPORT_OK   = qw( fun method after around before override augment classmethod objectmethod multi );
 our %EXPORT_TAGS = (
 	modifiers    => [qw( after around before )],
 	allmodifiers => [qw( after around before override augment )],


### PR DESCRIPTION
First, thank you so much for Kavorka. I love the implicit use of `dwim_type` and the `multi`s.

Speaking of which: [The documentation](https://metacpan.org/pod/Kavorka#Exports) says that `use Kavorka -all;` will export (among others) the `multi` keyword, but `multi` wasn't mentioned in `@EXPORT_OK` so that didn't work and you had to export `multi` explicitly.

This commit just adds `multi` into `@EXPORT_OK`, sticking to the documentation.
