### PR TITLE
fix broken links to Kavorka::Manual::Signatures (final "s" were missing)

### DIFF
--- a/lib/Kavorka/Manual/Functions.pod
+++ b/lib/Kavorka/Manual/Functions.pod
@@ -97,7 +97,7 @@ for a function name:
 
 =head2 The Signature
 
-See L<Kavorka::Manual::Signature>.
+See L<Kavorka::Manual::Signatures>.
 
 =head2 Traits
 
@@ -127,7 +127,7 @@ L<http://rt.cpan.org/Dist/Display.html?Queue=Kavorka>.
 =head1 SEE ALSO
 
 L<Kavorka::Manual>,
-L<Kavorka::Manual::Signature>,
+L<Kavorka::Manual::Signatures>,
 L<Kavorka::Manual::PrototypeAndAttributes>,
 L<Kavorka::Manual::MultiSubs>.
 

--- a/lib/Kavorka/Manual/MethodModifiers.pod
+++ b/lib/Kavorka/Manual/MethodModifiers.pod
@@ -78,7 +78,7 @@ Multiple names may be separated by colons:
 
 =head2 The Signature
 
-See L<Kavorka::Manual::Signature>.
+See L<Kavorka::Manual::Signatures>.
 
 The C<before> and C<after> keywords have a default invocant called
 C<< $self >>, but it does not have a type constraint, so can equally
@@ -126,7 +126,7 @@ L<http://rt.cpan.org/Dist/Display.html?Queue=Kavorka>.
 =head1 SEE ALSO
 
 L<Kavorka::Manual>,
-L<Kavorka::Manual::Signature>,
+L<Kavorka::Manual::Signatures>,
 L<Kavorka::Manual::PrototypeAndAttributes>,
 L<Kavorka::Manual::Methods>.
 

--- a/lib/Kavorka/Manual/Methods.pod
+++ b/lib/Kavorka/Manual/Methods.pod
@@ -105,7 +105,7 @@ See also: L<Lexical::Accessor>.
 
 =head2 The Signature
 
-See L<Kavorka::Manual::Signature>.
+See L<Kavorka::Manual::Signatures>.
 
 The C<method> keyword has a default invocant called C<< $self >>, but
 it does not have a type constraint, so can equally be used for class or
@@ -169,7 +169,7 @@ L<http://rt.cpan.org/Dist/Display.html?Queue=Kavorka>.
 =head1 SEE ALSO
 
 L<Kavorka::Manual>,
-L<Kavorka::Manual::Signature>,
+L<Kavorka::Manual::Signatures>,
 L<Kavorka::Manual::PrototypeAndAttributes>,
 L<Kavorka::Manual::MultiSubs>,
 L<Kavorka::Manual::MethodModifiers>.

--- a/lib/Kavorka/Manual/MultiSubs.pod
+++ b/lib/Kavorka/Manual/MultiSubs.pod
@@ -99,7 +99,7 @@ L<http://rt.cpan.org/Dist/Display.html?Queue=Kavorka>.
 =head1 SEE ALSO
 
 L<Kavorka::Manual>,
-L<Kavorka::Manual::Signature>,
+L<Kavorka::Manual::Signatures>,
 L<Kavorka::Manual::PrototypeAndAttributes>,
 L<Kavorka::Manual::Functions>,
 L<Kavorka::Manual::Methods>.


### PR DESCRIPTION
This just fixes a few broken links in the documentation. There currently are 7 `L<Kavorka::Manual::Signature>` links which lack the final "s" of `Kavorka/Manual/Signatures.pod` to work.
