### PR TITLE
Eliminate autovivification of %DEFERRED keys

### DIFF
--- a/lib/Kavorka.pm
+++ b/lib/Kavorka.pm
@@ -120,7 +120,7 @@ sub _exporter_fail
 	for (keys %Sub::Defer::DEFERRED) {
 		no warnings;
 		Sub::Defer::undefer_sub($_)
-			if $Sub::Defer::DEFERRED{$_}[0] =~ /\AKavorkaX?\b/;
+			if $Sub::Defer::DEFERRED{$_} && $Sub::Defer::DEFERRED{$_}[0] =~ /\AKavorkaX?\b/;
 	}
 	
 	# Kavorka::Multi (for example) needs to know what Kavorka keywords are


### PR DESCRIPTION
Autovivifying keys and subsequently calling undefer_sub causes "a cannot use undef as a SCALAR reference error."  This patch fixes that problem.

It would be cool of Sub::Defer had an API for accessing keys on a regex. :)
