### PR TITLE
Add markdown README for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Kavorka
+
+Function signatures with the lure of the animal
+
+## Installation
+
+The best way to install Kavorka is via `cpanm`:
+
+    $ cpanm Kavorka
+
+Alternative installation instructions can be found in the `INSTALL` file in
+the CPAN distribution tarball.
+
+## Building from source
+
+Clone the source:
+
+    $ git clone https://github.com/tobyink/p5-kavorka.git
+    $ cd p5-kavorka
+
+Install the dependencies:
+
+    $ cpanm Dist::Inkt Dist::Inkt::Profile::TOBYINK \
+            Parse::Keyword namespace::sweep Data::Alias Return::Type
+            Moops Text::sprintfn
+    $ cpanm -U Kavorka  # installed as a dependency of Moops
+
+Run the distribution build program:
+
+    $ distinkt-dist     # builds the dist tarball and runs the test suite
+
+## Running the test suite
+
+One can simply run `prove` in the usual manner:
+
+    $ prove -lr t


### PR DESCRIPTION
This contains instructions how to build the distribution from source and how
to run the test suite.  I'm aware that a README exists in the distribution
tarball, however this adds a README to GitHub and thus gives users some
information about the project when they see it on GitHub and how they can go
about installing, building, and testing the distribution.

This PR is submitted in the hope that it is useful.  Commens and/or questions are most certainly welcome.
