### PR TITLE
Data::Alias is broken on perl >= 5.24

### DIFF
--- a/lib/Kavorka/Signature.pm
+++ b/lib/Kavorka/Signature.pm
@@ -279,10 +279,9 @@ sub _injection_hash_underscore
 	or $slurpy && $slurpy->name =~ /\A\$/ && $slurpy->type->is_a_type_of(Types::Standard::HashRef()))
 	{
 		my $ix  = 1 + $self->last_position;
-		my $format;
 		my $str;
 		if (HAS_REFALIASING) {
-			$format = <<'EOF';
+			my $format = <<'EOF';
 local %%_;
 {
 	use Carp qw(croak);
@@ -312,14 +311,10 @@ EOF
 		}
 		else {
 			require Data::Alias;
-			$format = <<'EOF';
-local %%_;
-{
-	use warnings FATAL => qw(all);
-	Data::Alias::alias(%%_ = ($#_==%d && ref($_[%d]) eq q(HASH)) ? %%{$_[%d]} : @_[ %d .. $#_ ]);
- };
-EOF
-			$str = sprintf($format,($ix) x 5,);
+			$str = sprintf(
+			'local %%_; { use warnings FATAL => qw(all); Data::Alias::alias(%%_ = ($#_==%d && ref($_[%d]) eq q(HASH)) ? %%{$_[%d]} : @_[ %d .. $#_ ]) };',
+			($ix) x 4,
+		);
 		}
 
 		unless ($slurpy or $self->yadayada)

--- a/lib/Kavorka/Signature.pm
+++ b/lib/Kavorka/Signature.pm
@@ -19,6 +19,8 @@ use Parse::KeywordX;
 use Moo;
 use namespace::sweep;
 
+use constant HAS_REFALIASING => ($] >= 5.022);
+
 has package           => (is => 'ro');
 has _is_dummy         => (is => 'ro');
 has params            => (is => 'ro',  default => sub { +[] });
@@ -276,13 +278,50 @@ sub _injection_hash_underscore
 	or $slurpy && $slurpy->name =~ /\A\%/
 	or $slurpy && $slurpy->name =~ /\A\$/ && $slurpy->type->is_a_type_of(Types::Standard::HashRef()))
 	{
-		require Data::Alias;
 		my $ix  = 1 + $self->last_position;
-		my $str = sprintf(
-			'local %%_; { use warnings FATAL => qw(all); Data::Alias::alias(%%_ = ($#_==%d && ref($_[%d]) eq q(HASH)) ? %%{$_[%d]} : @_[ %d .. $#_ ]) };',
-			($ix) x 4,
-		);
-		
+		my $format;
+		my $str;
+		if (HAS_REFALIASING) {
+			$format = <<'EOF';
+local %%_;
+{
+	use Carp qw(croak);
+	use experimental 'refaliasing';
+
+	if ($#_==%d && ref($_[%d]) eq q(HASH)) {
+		\%%_ = \%%{$_[%d]};
+	}
+	else {
+		# Make a hash reference from array refalias does not work
+		# Manual build
+		my $slice_length = ($#_ + 1 - %d);
+		if ($slice_length %% 2 != 0) {
+			# Seems to be what t/10positional.t wants
+			croak("Odd number of elements in anonymous hash");
+		}
+		my $i = %d;
+		while ($i <= $#_) {
+			my $key = $_[$i];
+			\$_{$key} = \$_[$i+1];
+			$i += 2;
+		}
+	}
+};
+EOF
+			$str = sprintf($format,($ix) x 5,);
+		}
+		else {
+			require Data::Alias;
+			$format = <<'EOF';
+local %%_;
+{
+	use warnings FATAL => qw(all);
+	Data::Alias::alias(%%_ = ($#_==%d && ref($_[%d]) eq q(HASH)) ? %%{$_[%d]} : @_[ %d .. $#_ ]);
+ };
+EOF
+			$str = sprintf($format,($ix) x 5,);
+		}
+
 		unless ($slurpy or $self->yadayada)
 		{
 			my @allowed_names = map +($_=>1), map @{$_->named_names}, $self->named_params;

--- a/lib/Kavorka/TraitFor/Parameter/alias.pm
+++ b/lib/Kavorka/TraitFor/Parameter/alias.pm
@@ -28,14 +28,12 @@ my %s;
 	\%s = \do { %s };
 };
 EOF
+			return sprintf($format, ($var) x 2, $val);
 		}
 		else {
 			require Data::Alias;
-			$format = <<'EOF';
-Data::Alias::alias(my %s = do { %s });
-EOF
+			return sprintf('Data::Alias::alias(my %s = do { %s });', $var, $val);
 		}
-		return sprintf($format, ($var) x 2, $val);
 	}
 	elsif ($self->kind eq 'our')
 	{

--- a/lib/Kavorka/TraitFor/Parameter/alias.pm
+++ b/lib/Kavorka/TraitFor/Parameter/alias.pm
@@ -9,6 +9,8 @@ our $VERSION   = '0.035';
 
 use Moo::Role;
 
+use constant HAS_REFALIASING => ($] >= 5.022);
+
 around _injection_assignment => sub
 {
 	my $next = shift;
@@ -17,8 +19,23 @@ around _injection_assignment => sub
 	
 	if ($self->kind eq 'my')
 	{
-		require Data::Alias;
-		return sprintf('Data::Alias::alias(my %s = do { %s });', $var, $val);
+		my $format;
+		if (HAS_REFALIASING) {
+			$format = <<'EOF';
+my %s;
+{
+	use experimental 'refaliasing';
+	\%s = \do { %s };
+};
+EOF
+		}
+		else {
+			require Data::Alias;
+			$format = <<'EOF';
+Data::Alias::alias(my %s = do { %s });
+EOF
+		}
+		return sprintf($format, ($var) x 2, $val);
 	}
 	elsif ($self->kind eq 'our')
 	{

--- a/lib/Kavorka/TraitFor/Parameter/ref_alias.pm
+++ b/lib/Kavorka/TraitFor/Parameter/ref_alias.pm
@@ -32,11 +32,7 @@ EOF
 		}
 		else {
 			require Data::Alias;
-			$format = <<'EOF';
-Data::Alias::alias(my %s = %s{ +do { %s } });
-EOF
-
-			return sprintf($format, $var, $self->sigil, $val);
+			return sprintf('Data::Alias::alias(my %s = %s{ +do { %s } });', $var, $self->sigil, $val);
 		}
 	}
 	elsif ($self->kind eq 'our')


### PR DESCRIPTION
The Data::Alias module itself explains:

    “...you should prefer to use the core facility rather than use this
    module. If you are already using this module and are now using a
    sufficiently recent Perl, you should attempt to migrate to the core
    facility...”

The idea is to use core refaliasing when available and Data::Alias
otherwise.